### PR TITLE
Supports various skill rolls

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,7 +11,7 @@ use crate::commands::choose::ChooseCommand;
 use crate::commands::create_sheet::CSCommand;
 use crate::commands::roll::RollCommand;
 use crate::commands::set::SetCommand;
-use crate::commands::skill::{Sk5Command, Sk7Command, SkillCommand};
+use crate::commands::skill::{Sk5Command, Sk7Command, SkDGCommand, SkillCommand};
 use crate::commands::status::StatusCommand;
 use crate::database::SizedBotDatabase;
 use crate::log;
@@ -53,6 +53,7 @@ static REGISTERED_COMMANDS: Lazy<Vec<Box<dyn BotCommand + Sync + Send>>> = Lazy:
         Box::new(RollCommand),
         Box::new(Sk5Command),
         Box::new(Sk7Command),
+        Box::new(SkDGCommand),
         Box::new(SkillCommand),
         Box::new(SetCommand),
         Box::new(StatusCommand),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,7 +11,7 @@ use crate::commands::choose::ChooseCommand;
 use crate::commands::create_sheet::CSCommand;
 use crate::commands::roll::RollCommand;
 use crate::commands::set::SetCommand;
-use crate::commands::skill::{Sk5Command, Sk7Command, SkBRPCommand, SkDGCommand, SkillCommand};
+use crate::commands::skill::{Sk6Command, Sk7Command, SkBRPCommand, SkDGCommand, SkillCommand};
 use crate::commands::status::StatusCommand;
 use crate::database::SizedBotDatabase;
 use crate::log;
@@ -51,7 +51,7 @@ static REGISTERED_COMMANDS: Lazy<Vec<Box<dyn BotCommand + Sync + Send>>> = Lazy:
         Box::new(ChooseCommand),
         Box::new(CSCommand),
         Box::new(RollCommand),
-        Box::new(Sk5Command),
+        Box::new(Sk6Command),
         Box::new(Sk7Command),
         Box::new(SkDGCommand),
         Box::new(SkBRPCommand),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,7 +11,7 @@ use crate::commands::choose::ChooseCommand;
 use crate::commands::create_sheet::CSCommand;
 use crate::commands::roll::RollCommand;
 use crate::commands::set::SetCommand;
-use crate::commands::skill::SkillCommand;
+use crate::commands::skill::{Sk5Command, Sk7Command, SkillCommand};
 use crate::commands::status::StatusCommand;
 use crate::database::SizedBotDatabase;
 use crate::log;
@@ -51,6 +51,8 @@ static REGISTERED_COMMANDS: Lazy<Vec<Box<dyn BotCommand + Sync + Send>>> = Lazy:
         Box::new(ChooseCommand),
         Box::new(CSCommand),
         Box::new(RollCommand),
+        Box::new(Sk5Command),
+        Box::new(Sk7Command),
         Box::new(SkillCommand),
         Box::new(SetCommand),
         Box::new(StatusCommand),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,7 +11,7 @@ use crate::commands::choose::ChooseCommand;
 use crate::commands::create_sheet::CSCommand;
 use crate::commands::roll::RollCommand;
 use crate::commands::set::SetCommand;
-use crate::commands::skill::{Sk5Command, Sk7Command, SkDGCommand, SkillCommand};
+use crate::commands::skill::{Sk5Command, Sk7Command, SkBRPCommand, SkDGCommand, SkillCommand};
 use crate::commands::status::StatusCommand;
 use crate::database::SizedBotDatabase;
 use crate::log;
@@ -54,6 +54,7 @@ static REGISTERED_COMMANDS: Lazy<Vec<Box<dyn BotCommand + Sync + Send>>> = Lazy:
         Box::new(Sk5Command),
         Box::new(Sk7Command),
         Box::new(SkDGCommand),
+        Box::new(SkBRPCommand),
         Box::new(SkillCommand),
         Box::new(SetCommand),
         Box::new(StatusCommand),

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -6,33 +6,18 @@ use serenity::prelude::{Context, Mutex};
 
 use crate::commands::{BotCommand, CommandStatus, InteractionUtil, SendEmbed};
 
-/// A command that does a skill roll.
+/// A command that does a skill roll. It follows Call of Cthulhu 5th Edition.
 pub struct SkillCommand;
 
-#[naming]
-#[db_required(false)]
-#[serenity::async_trait]
-impl BotCommand for SkillCommand {
-    fn register(&self, command: &mut CreateApplicationCommand) {
-        command
-            .description("Attempts a skill roll. In other words, rolls 1d100. | 技能ロールを行います. 1d100を振って判定します.")
-            .create_option(|option| {
-                option
-                    .name("value")
-                    .kind(CommandOptionType::Integer)
-                    .description("A skill value | 技能値")
-                    .required(true)
-            })
-            .create_option(|option| {
-                option
-                    .name("comment")
-                    .kind(CommandOptionType::String)
-                    .description("A comment | ダイスの説明")
-            });
-    }
+/// A command that does a skill roll. It follows Call of Cthulhu 5th Edition.
+pub struct Sk5Command;
 
-    async fn execute(
-        &self,
+/// A command that does a skill roll. It follows Call of Cthulhu 7th Edition.
+pub struct Sk7Command;
+
+impl SkillCommand {
+    /// Does a skill roll following the rule of Call of Cthulhu 5th Edition.
+    async fn execute_5th(
         ctx: &Context,
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
@@ -69,5 +54,139 @@ impl BotCommand for SkillCommand {
             .await?;
 
         Ok(CommandStatus::Ok)
+    }
+
+    /// Does a skill roll following the rule of Call of Cthulhu 7th Edition.
+    async fn execute_7th(
+        ctx: &Context,
+        interaction: &ApplicationCommandInteraction,
+    ) -> Result<CommandStatus> {
+        let value = interaction.get_int_option("value".to_string()).unwrap();
+
+        let comment = interaction
+            .get_string_option("comment".to_string())
+            .unwrap_or("a skill");
+
+        let (result, roll) = match d20::roll_dice("1d100").unwrap().total {
+            result if (result == 1 && result <= value) => (
+                ":star::crown::star: **Critical!!!**",
+                format!("1 <= {}", value),
+            ),
+            result if result <= value / 5 => (
+                ":crown: **Extreme Success!**",
+                format!("{} <= {} / 5", result, value),
+            ),
+            result if result <= value / 2 => (
+                ":o: **Hard Success!**",
+                format!("{} <= {} / 2", result, value),
+            ),
+            result if result == 100 || (result > 95 && value < 50) => {
+                (":skull: **Fumble!**", format!("{} >= {}", result, value))
+            }
+            result if result <= value => (":o: **Success**", format!("{} <= {}", result, value)),
+            result => (":x: **Failed**", format!("{} > {}", result, value)),
+        };
+
+        interaction
+            .send_embed(ctx, |embed| {
+                embed.title(format!("{} uses {}", interaction.get_nickname(), comment));
+                embed.field(result, roll, false)
+            })
+            .await?;
+
+        Ok(CommandStatus::Ok)
+    }
+}
+
+#[naming]
+#[db_required(false)]
+#[serenity::async_trait]
+impl BotCommand for SkillCommand {
+    fn register(&self, command: &mut CreateApplicationCommand) {
+        command
+            .description("Does a skill roll. `/sk5` is the same. | 技能ロールを行います. `/sk5`と同じ動きをします.")
+            .create_option(|option| {
+                option
+                    .name("value")
+                    .kind(CommandOptionType::Integer)
+                    .description("A skill value | 技能値")
+                    .required(true)
+            })
+            .create_option(|option| {
+                option
+                    .name("comment")
+                    .kind(CommandOptionType::String)
+                    .description("A comment | ダイスの説明")
+            });
+    }
+
+    async fn execute(
+        &self,
+        ctx: &Context,
+        interaction: &ApplicationCommandInteraction,
+    ) -> Result<CommandStatus> {
+        Self::execute_5th(ctx, interaction).await
+    }
+}
+
+#[naming]
+#[db_required(false)]
+#[serenity::async_trait]
+impl BotCommand for Sk5Command {
+    fn register(&self, command: &mut CreateApplicationCommand) {
+        command
+            .description("Does a skill roll under Call of Cthulhu 5th Edition. | 第5版に則り, 技能ロールを行います.")
+            .create_option(|option| {
+                option
+                    .name("value")
+                    .kind(CommandOptionType::Integer)
+                    .description("A skill value | 技能値")
+                    .required(true)
+            })
+            .create_option(|option| {
+                option
+                    .name("comment")
+                    .kind(CommandOptionType::String)
+                    .description("A comment | ダイスの説明")
+            });
+    }
+
+    async fn execute(
+        &self,
+        ctx: &Context,
+        interaction: &ApplicationCommandInteraction,
+    ) -> Result<CommandStatus> {
+        SkillCommand::execute_5th(ctx, interaction).await
+    }
+}
+
+#[naming]
+#[db_required(false)]
+#[serenity::async_trait]
+impl BotCommand for Sk7Command {
+    fn register(&self, command: &mut CreateApplicationCommand) {
+        command
+            .description("Does a skill roll under Call of Cthulhu 7th Edition. | 第7版に則り, 技能ロールを行います.")
+            .create_option(|option| {
+                option
+                    .name("value")
+                    .kind(CommandOptionType::Integer)
+                    .description("A skill value | 技能値")
+                    .required(true)
+            })
+            .create_option(|option| {
+                option
+                    .name("comment")
+                    .kind(CommandOptionType::String)
+                    .description("A comment | ダイスの説明")
+            });
+    }
+
+    async fn execute(
+        &self,
+        ctx: &Context,
+        interaction: &ApplicationCommandInteraction,
+    ) -> Result<CommandStatus> {
+        SkillCommand::execute_7th(ctx, interaction).await
     }
 }

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -6,11 +6,11 @@ use serenity::prelude::{Context, Mutex};
 
 use crate::commands::{BotCommand, CommandStatus, InteractionUtil, SendEmbed};
 
-/// A command that does a skill roll. It follows Call of Cthulhu 5th Edition.
+/// A command that does a skill roll. It follows Call of Cthulhu 6th Edition.
 pub struct SkillCommand;
 
-/// A command that does a skill roll. It follows Call of Cthulhu 5th Edition.
-pub struct Sk5Command;
+/// A command that does a skill roll. It follows Call of Cthulhu 6th Edition.
+pub struct Sk6Command;
 
 /// A command that does a skill roll. It follows Call of Cthulhu 7th Edition.
 pub struct Sk7Command;
@@ -22,8 +22,8 @@ pub struct SkDGCommand;
 pub struct SkBRPCommand;
 
 impl SkillCommand {
-    /// Does a skill roll following the rule of Call of Cthulhu 5th Edition.
-    async fn execute_5th(
+    /// Does a skill roll following the rule of Call of Cthulhu 6th Edition.
+    async fn execute_6th(
         ctx: &Context,
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
@@ -187,7 +187,7 @@ impl SkillCommand {
 impl BotCommand for SkillCommand {
     fn register(&self, command: &mut CreateApplicationCommand) {
         command
-            .description("Does a skill roll following the Call of Cthulhu 5th Edition. `/sk5` is the same. | 第5版のルールに基づいて技能ロールを行います. `/sk5`と同じ動きをします.")
+            .description("Does a skill roll following the Call of Cthulhu 6th Edition. `/sk6` is the same. | 第6版のルールに基づいて技能ロールを行います. `/sk6`と同じ動きをします.")
             .create_option(|option| {
                 option
                     .name("chance")
@@ -208,17 +208,17 @@ impl BotCommand for SkillCommand {
         ctx: &Context,
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
-        Self::execute_5th(ctx, interaction).await
+        Self::execute_6th(ctx, interaction).await
     }
 }
 
 #[naming]
 #[db_required(false)]
 #[serenity::async_trait]
-impl BotCommand for Sk5Command {
+impl BotCommand for Sk6Command {
     fn register(&self, command: &mut CreateApplicationCommand) {
         command
-            .description("Does a skill roll following the Call of Cthulhu 5th Edition. | 第5版のルールに基づいて技能ロールを行います.")
+            .description("Does a skill roll following the Call of Cthulhu 6th Edition. | 第6版のルールに基づいて技能ロールを行います.")
             .create_option(|option| {
                 option
                     .name("chance")
@@ -239,7 +239,7 @@ impl BotCommand for Sk5Command {
         ctx: &Context,
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
-        SkillCommand::execute_5th(ctx, interaction).await
+        SkillCommand::execute_6th(ctx, interaction).await
     }
 }
 

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -18,35 +18,38 @@ pub struct Sk7Command;
 /// A command that does a skill roll. It follows Delta Green.
 pub struct SkDGCommand;
 
+/// A command that does a skill roll. It follows the BRP 2023 rule book.
+pub struct SkBRPCommand;
+
 impl SkillCommand {
     /// Does a skill roll following the rule of Call of Cthulhu 5th Edition.
     async fn execute_5th(
         ctx: &Context,
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
-        let value = interaction.get_int_option("value".to_string()).unwrap();
+        let chance = interaction.get_int_option("chance".to_string()).unwrap();
 
         let comment = interaction
             .get_string_option("comment".to_string())
             .unwrap_or("a skill");
 
         let (result, roll) = match d20::roll_dice("1d100").unwrap().total {
-            result if (result == 1 && result <= value) => (
+            result if (result == 1 && result <= chance) => (
                 ":star::crown::star: **Critical!!!**",
-                format!("1 <= {}", value),
+                format!("1 <= {}", chance),
             ),
-            result if result <= 5 && (result <= value) => {
-                (":crown: **Critical!**", format!("{} <= {}", result, value))
+            result if result <= 5 && (result <= chance) => {
+                (":crown: **Critical!**", format!("{} <= {}", result, chance))
             }
-            result if result == 100 && (result > value) => (
+            result if result == 100 && (result > chance) => (
                 ":fire::skull::fire: **Fumble!!!**",
-                format!("100 > {}", value),
+                format!("100 > {}", chance),
             ),
-            result if result > 95 && (result > value) => {
-                (":skull: **Fumble!**", format!("{} > {}", result, value))
+            result if result > 95 && (result > chance) => {
+                (":skull: **Fumble!**", format!("{} > {}", result, chance))
             }
-            result if result <= value => (":o: **Success**", format!("{} <= {}", result, value)),
-            result => (":x: **Failed**", format!("{} > {}", result, value)),
+            result if result <= chance => (":o: **Success**", format!("{} <= {}", result, chance)),
+            result => (":x: **Failed**", format!("{} > {}", result, chance)),
         };
 
         interaction
@@ -64,30 +67,30 @@ impl SkillCommand {
         ctx: &Context,
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
-        let value = interaction.get_int_option("value".to_string()).unwrap();
+        let chance = interaction.get_int_option("chance".to_string()).unwrap();
 
         let comment = interaction
             .get_string_option("comment".to_string())
             .unwrap_or("a skill");
 
         let (result, roll) = match d20::roll_dice("1d100").unwrap().total {
-            result if (result == 1 && result <= value) => (
+            result if (result == 1 && result <= chance) => (
                 ":star::crown::star: **Critical!!!**",
-                format!("1 <= {}", value),
+                format!("1 <= {}", chance),
             ),
-            result if result <= value / 5 => (
+            result if result <= chance / 5 => (
                 ":crown: **Extreme Success!**",
-                format!("{} <= {} / 5", result, value),
+                format!("{} <= {} / 5", result, chance),
             ),
-            result if result <= value / 2 => (
+            result if result <= chance / 2 => (
                 ":o: **Hard Success!**",
-                format!("{} <= {} / 2", result, value),
+                format!("{} <= {} / 2", result, chance),
             ),
-            result if result == 100 || (result > 95 && value < 50) => {
-                (":skull: **Fumble!**", format!("{} >= {}", result, value))
+            result if result == 100 || (result > 95 && chance < 50) => {
+                (":skull: **Fumble!**", format!("{} >= {}", result, chance))
             }
-            result if result <= value => (":o: **Success**", format!("{} <= {}", result, value)),
-            result => (":x: **Failed**", format!("{} > {}", result, value)),
+            result if result <= chance => (":o: **Success**", format!("{} <= {}", result, chance)),
+            result => (":x: **Failed**", format!("{} > {}", result, chance)),
         };
 
         interaction
@@ -104,32 +107,67 @@ impl SkillCommand {
         ctx: &Context,
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
-        let value = interaction.get_int_option("value".to_string()).unwrap();
+        let chance = interaction.get_int_option("chance".to_string()).unwrap();
 
         let comment = interaction
             .get_string_option("comment".to_string())
             .unwrap_or("a skill");
 
         let (result, roll) = match d20::roll_dice("1d100").unwrap().total {
-            result if (result == 1 && result <= value) => (
+            result if (result == 1 && result <= chance) => (
                 ":star::crown::star: **Critical!!!**",
-                format!("1 <= {}", value),
+                format!("1 <= {}", chance),
             ),
-            result if result <= 5 && (result <= value) => {
-                (":crown: **Critical!**", format!("{} <= {}", result, value))
+            result if result <= 5 && (result <= chance) => {
+                (":crown: **Critical!**", format!("{} <= {}", result, chance))
             }
-            result if result / 10 == result % 10 && result <= value => {
-                (":crown: **Critical!**", format!("{} <= {}", result, value))
-            },
-            result if result == 100 && (result > value) => (
+            result if result / 10 == result % 10 && result <= chance => {
+                (":crown: **Critical!**", format!("{} <= {}", result, chance))
+            }
+            result if result == 100 && (result > chance) => (
                 ":fire::skull::fire: **Fumble!!!**",
-                format!("100 > {}", value),
+                format!("100 > {}", chance),
             ),
-            result if result > 95 && (result > value) => {
-                (":skull: **Fumble!**", format!("{} > {}", result, value))
+            result if result > 95 && (result > chance) => {
+                (":skull: **Fumble!**", format!("{} > {}", result, chance))
             }
-            result if result <= value => (":o: **Success**", format!("{} <= {}", result, value)),
-            result => (":x: **Failed**", format!("{} > {}", result, value)),
+            result if result <= chance => (":o: **Success**", format!("{} <= {}", result, chance)),
+            result => (":x: **Failed**", format!("{} > {}", result, chance)),
+        };
+
+        interaction
+            .send_embed(ctx, |embed| {
+                embed.title(format!("{} uses {}", interaction.get_nickname(), comment));
+                embed.field(result, roll, false)
+            })
+            .await?;
+
+        Ok(CommandStatus::Ok)
+    }
+
+    async fn execute_brp(
+        ctx: &Context,
+        interaction: &ApplicationCommandInteraction,
+    ) -> Result<CommandStatus> {
+        let chance = interaction.get_int_option("chance".to_string()).unwrap();
+
+        let comment = interaction
+            .get_string_option("comment".to_string())
+            .unwrap_or("a skill");
+
+        let (result, roll) = match d20::roll_dice("1d100").unwrap().total {
+            result if result <= (chance - 1) / 20 + 1 => (
+                ":star::crown::star: **Critical!!!**",
+                format!("{} <= {}", result, chance),
+            ),
+            result if result <= (chance - 1) / 5 + 1 => {
+                (":crown: **Special!**", format!("{} <= {}", result, chance))
+            }
+            result if result >= i32::min(96 + (chance - 1) / 20, 100) && (result > chance) => {
+                (":skull: **Fumble!**", format!("{} > {}", result, chance))
+            }
+            result if result <= chance => (":o: **Success**", format!("{} <= {}", result, chance)),
+            result => (":x: **Failed**", format!("{} > {}", result, chance)),
         };
 
         interaction
@@ -149,12 +187,12 @@ impl SkillCommand {
 impl BotCommand for SkillCommand {
     fn register(&self, command: &mut CreateApplicationCommand) {
         command
-            .description("Does a skill roll. `/sk5` is the same. | 技能ロールを行います. `/sk5`と同じ動きをします.")
+            .description("Does a skill roll following the Call of Cthulhu 5th Edition. `/sk5` is the same. | 第5版のルールに基づいて技能ロールを行います. `/sk5`と同じ動きをします.")
             .create_option(|option| {
                 option
-                    .name("value")
+                    .name("chance")
                     .kind(CommandOptionType::Integer)
-                    .description("A skill value | 技能値")
+                    .description("A skill chance | 技能値")
                     .required(true)
             })
             .create_option(|option| {
@@ -180,12 +218,12 @@ impl BotCommand for SkillCommand {
 impl BotCommand for Sk5Command {
     fn register(&self, command: &mut CreateApplicationCommand) {
         command
-            .description("Does a skill roll under Call of Cthulhu 5th Edition. | 第5版に則り, 技能ロールを行います.")
+            .description("Does a skill roll following the Call of Cthulhu 5th Edition. | 第5版のルールに基づいて技能ロールを行います.")
             .create_option(|option| {
                 option
-                    .name("value")
+                    .name("chance")
                     .kind(CommandOptionType::Integer)
-                    .description("A skill value | 技能値")
+                    .description("A skill chance | 技能値")
                     .required(true)
             })
             .create_option(|option| {
@@ -211,12 +249,12 @@ impl BotCommand for Sk5Command {
 impl BotCommand for Sk7Command {
     fn register(&self, command: &mut CreateApplicationCommand) {
         command
-            .description("Does a skill roll under Call of Cthulhu 7th Edition. | 第7版に則り, 技能ロールを行います.")
+            .description("Does a skill roll following the Call of Cthulhu 7th Edition. | 第7版のルールに基づいて技能ロールを行います.")
             .create_option(|option| {
                 option
-                    .name("value")
+                    .name("chance")
                     .kind(CommandOptionType::Integer)
-                    .description("A skill value | 技能値")
+                    .description("A skill chance | 技能値")
                     .required(true)
             })
             .create_option(|option| {
@@ -242,12 +280,12 @@ impl BotCommand for Sk7Command {
 impl BotCommand for SkDGCommand {
     fn register(&self, command: &mut CreateApplicationCommand) {
         command
-            .description("Does a skill roll following the rule of Delta Green. | Delta Greenのルールに基づいて技能ロールを行います.")
+            .description("Does a skill roll following the Delta Green. | Delta Greenのルールに基づいて技能ロールを行います.")
             .create_option(|option| {
                 option
-                    .name("value")
+                    .name("chance")
                     .kind(CommandOptionType::Integer)
-                    .description("A skill value | 技能値")
+                    .description("A skill chance | 技能値")
                     .required(true)
             })
             .create_option(|option| {
@@ -264,5 +302,36 @@ impl BotCommand for SkDGCommand {
         interaction: &ApplicationCommandInteraction,
     ) -> Result<CommandStatus> {
         SkillCommand::execute_dg(ctx, interaction).await
+    }
+}
+
+#[naming]
+#[db_required(false)]
+#[serenity::async_trait]
+impl BotCommand for SkBRPCommand {
+    fn register(&self, command: &mut CreateApplicationCommand) {
+        command
+            .description("Does a skill roll following the BRP 2023. | BRP 2023のルールに基づいて技能ロールを行います.")
+            .create_option(|option| {
+                option
+                    .name("chance")
+                    .kind(CommandOptionType::Integer)
+                    .description("A skill chance | 技能値")
+                    .required(true)
+            })
+            .create_option(|option| {
+                option
+                    .name("comment")
+                    .kind(CommandOptionType::String)
+                    .description("A comment | ダイスの説明")
+            });
+    }
+
+    async fn execute(
+        &self,
+        ctx: &Context,
+        interaction: &ApplicationCommandInteraction,
+    ) -> Result<CommandStatus> {
+        SkillCommand::execute_brp(ctx, interaction).await
     }
 }


### PR DESCRIPTION
Supports the feature described in #23.
Here are new commands:
- `/sk6`: `/skill` is the same.
- `/sk7`: The CoC 7th Edition support. i.e. Hard success and extreme success support.
- `/skbrp`: The new BRP 2023 rulebook support.
- `/skdg`: The Delta Green support. 