### PR TITLE
Load bot configurations from an external file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ d20 = "0.1.0"
 once_cell = "1.9.0"
 rand = "0.8.5"
 regex = "1.5.4"
+serde = { version = "1.0.195", features=["derive"] }
+serde_json = "1.0.111"
 serenity = { version = "0.11", default-features = false, features = ["client", "gateway", "rustls_backend", "model", "unstable_discord_api"] }
 sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres" ] }
 tokio = { version = "1.30", features = ["rt-multi-thread"] }

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+    "discord_token": "xxxxx",
+    "log_path": "~/logs/cthulhu_bot",
+    "status_message": "Call of Cthulhu"
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,6 +37,7 @@ impl BotConfigError {
 pub struct BotConfig {
     pub discord_token: String,
     pub log_path: String,
+    pub status_message: String,
     pub database_url: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+use std::env;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::fs::File;
+use std::io::BufReader;
+
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use serenity::prelude::Mutex;
+
+/// Holds error information related to the process of loading the configurations.
+/// This should be used to handle errors triggered before the logging system is up.
+#[derive(Debug)]
+pub struct BotConfigError {
+    message: String,
+}
+
+impl Display for BotConfigError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for BotConfigError {}
+
+impl BotConfigError {
+    pub fn new(message: &str) -> Self {
+        BotConfigError {
+            message: message.to_string(),
+        }
+    }
+}
+
+/// A set of configurations of this bot.
+#[derive(Deserialize)]
+pub struct BotConfig {
+    pub discord_token: String,
+    pub log_path: String,
+    pub database_url: Option<String>,
+}
+
+/// Holds the configurations of this bot. You need to call `BotConfig::load_from_file` before using this.
+pub static BOT_CONFIG: Lazy<Mutex<Option<BotConfig>>> = Lazy::new(|| Mutex::new(None));
+
+impl BotConfig {
+    /// Loads `BOT_CONFIG` from `./config.json`.
+    pub async fn load_from_file() -> Result<()> {
+        let executable_path = env::current_exe()?;
+        let executable_dir = executable_path.parent().ok_or(BotConfigError::new(
+            "Cannot retrieve the parent of this executable.",
+        ))?;
+
+        let config_file = executable_dir.join("config.json");
+        if config_file.exists() {
+            let config_file = File::open(config_file)?;
+            let reader = BufReader::new(config_file);
+
+            let config: BotConfig = serde_json::from_reader(reader)?;
+            {
+                let mut saved_config = BOT_CONFIG.lock().await;
+                *saved_config = Some(config);
+            }
+
+            Ok(())
+        } else {
+            Err(BotConfigError::new(
+                "No configuration file is provided. Create a new \"config.json\" in the directory where this bot is placed.",
+            ))?
+        }
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,9 +3,10 @@ use serenity::model::prelude::{Activity, Ready};
 use serenity::prelude::{Context, EventHandler};
 
 use crate::commands::BotCommandManager;
+use crate::config::BOT_CONFIG;
 use crate::log;
 use crate::logging::Logger;
-use crate::{DATABASE, STATUS_MESSAGE};
+use crate::DATABASE;
 
 /// An event handler for the bot.
 pub struct BotHandler;
@@ -13,7 +14,13 @@ pub struct BotHandler;
 #[serenity::async_trait]
 impl EventHandler for BotHandler {
     async fn ready(&self, ctx: Context, ready: Ready) {
-        ctx.set_activity(Activity::playing(STATUS_MESSAGE)).await;
+        {
+            let config = BOT_CONFIG.lock().await;
+            assert!(config.is_some());
+
+            let status_message = &config.as_ref().unwrap().status_message;
+            ctx.set_activity(Activity::playing(status_message)).await;
+        }
 
         let db = DATABASE.lock().await;
         let result = BotCommandManager::register_all(&ctx, db.is_available()).await;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::Write;
 
 use anyhow::Result;
@@ -49,7 +49,7 @@ impl Logger {
         }
 
         let log_path = &config.as_ref().unwrap().log_path;
-        let file = File::create(log_path);
+        let file = OpenOptions::new().append(true).create(true).open(log_path);
         match file {
             Ok(file) => {
                 let mut log_file = LOG_FILE.lock().await;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::env;
 use std::fs::File;
 use std::io::Write;
 
@@ -8,6 +7,8 @@ use chrono::prelude::Local;
 use once_cell::sync::Lazy;
 use serenity::prelude::Mutex;
 use tokio::time::Duration;
+
+use crate::config::BOT_CONFIG;
 
 /// A kind of the log.
 pub enum LogKind {
@@ -42,17 +43,19 @@ pub struct Logger;
 impl Logger {
     /// Opens the log file and assign its handle to `LOG_FILE`.
     pub async fn init() {
-        if let Ok(log_path) = env::var("LOG_PATH") {
-            let file = File::create(log_path);
-            match file {
-                Ok(file) => {
-                    let mut log_file = LOG_FILE.lock().await;
-                    *log_file = Box::new(Some(file));
-                }
-                Err(err) => log!(ERROR, "{}", err),
+        let config = BOT_CONFIG.lock().await;
+        if config.is_none() {
+            log!(ERROR, "The config has not been initialized.");
+        }
+
+        let log_path = &config.as_ref().unwrap().log_path;
+        let file = File::create(log_path);
+        match file {
+            Ok(file) => {
+                let mut log_file = LOG_FILE.lock().await;
+                *log_file = Box::new(Some(file));
             }
-        } else {
-            log!(ERROR, "Failed to get LOG_PATH.");
+            Err(err) => log!(ERROR, "{}", err),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,6 @@ use crate::logging::Logger;
 pub static DATABASE: Lazy<Mutex<SizedBotDatabase>> =
     Lazy::new(|| Mutex::new(Box::new(DummyDatabase {})));
 
-/// A status message that shows up on the bot.
-pub const STATUS_MESSAGE: &str = "Call of Cthulhu";
-
 /// Initializes a bot and lets the bot start.
 async fn start_bot() -> Result<()> {
     // Read the configurations.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,12 @@
 #[macro_use]
 extern crate cmd_macro;
 
-use std::env;
-use std::io::{Error, ErrorKind};
-
 use anyhow::Result;
 use once_cell::sync::Lazy;
 use serenity::prelude::{GatewayIntents, Mutex};
 use serenity::Client;
 
+use crate::config::{BotConfig, BOT_CONFIG};
 use crate::database::{DummyDatabase, PgDatabase, SizedBotDatabase};
 use crate::handler::BotHandler;
 use crate::logging::Logger;
@@ -22,12 +20,22 @@ pub const STATUS_MESSAGE: &str = "Call of Cthulhu";
 
 /// Initializes a bot and lets the bot start.
 async fn start_bot() -> Result<()> {
-    // Load the environmental variables.
-    let token = env::var("DISCORD_TOKEN")
-        .map_err(|_| Error::new(ErrorKind::Other, "Failed to get DISCORD_TOKEN."))?;
+    // Read the configurations.
+    let (token, database_url) = {
+        let config = BOT_CONFIG.lock().await;
+        if config.is_none() {
+            log!(ERROR, "The config has not been initialized.");
+        }
+
+        let bot_config = config.as_ref().unwrap();
+        (
+            bot_config.discord_token.clone(),
+            bot_config.database_url.clone(),
+        )
+    };
 
     // Connect to the database.
-    if let Ok(database_url) = env::var("DATABASE_URL") {
+    if let Some(database_url) = database_url {
         let database = PgDatabase::init(&database_url).await?;
 
         let mut db = DATABASE.lock().await;
@@ -53,6 +61,10 @@ async fn start_bot() -> Result<()> {
 
 #[tokio::main]
 async fn main() {
+    // Load the configurations.
+    let result = BotConfig::load_from_file().await;
+    Logger::log_err(&result).await;
+
     Logger::init().await;
 
     Logger::publish_daily_reports();
@@ -62,6 +74,7 @@ async fn main() {
 }
 
 pub mod commands;
+pub mod config;
 pub mod database;
 pub mod handler;
 pub mod logging;


### PR DESCRIPTION
Switches a way to load configurations from environment variables to reading a JSON file named `./config.json`.